### PR TITLE
Testing rubypack

### DIFF
--- a/lib/rubypack/builder.rb
+++ b/lib/rubypack/builder.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'tmpdir'
 
 module Rubypack
   class Builder

--- a/lib/rubypack/builder.rb
+++ b/lib/rubypack/builder.rb
@@ -33,7 +33,7 @@ module Rubypack
       true
     rescue => exception
       @output.error(exception.message)
-      verbose(exception.backtrace.join("\n"))
+      @output.verbose(exception.backtrace.join("\n"))
       false
     end
 

--- a/lib/rubypack/version.rb
+++ b/lib/rubypack/version.rb
@@ -1,3 +1,3 @@
 module Rubypack
-  VERSION = "1.0.3"
+  VERSION = '1.0.4'
 end


### PR DESCRIPTION
There were two fixes
   
   Verbose is a function of QuietOutput and it was invoke as a function of builder, something crashed and this not allowed me to see what happened.

  After fixed the verbose method, I realized that ruby for some reason  didn't find the method 
'mktmpdir'

undefined method `mktmpdir' for Dir:Class
.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rubypack-1.0.4/lib/rubypack/builder.rb:28:in `build!'

the fix was require the library 'tmpdir'
